### PR TITLE
Use individual aws-sdk service gems

### DIFF
--- a/awsutils.gemspec
+++ b/awsutils.gemspec
@@ -32,11 +32,15 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug'
 
   spec.add_dependency 'awesome_print', '~> 1'
+  spec.add_dependency 'aws-sdk-cloudwatchlogs', '~> 1'
+  spec.add_dependency 'aws-sdk-ec2', '~> 1'
+  spec.add_dependency 'aws-sdk-elasticloadbalancing', '~> 1'
+  spec.add_dependency 'aws-sdk-elasticloadbalancingv2', '~> 1'
+  spec.add_dependency 'aws-sdk-route53', '~> 1'
   spec.add_dependency 'colorize', '~> 0.8.1'
   spec.add_dependency 'facets', '~> 2.9'
   spec.add_dependency 'highline', '~> 2.0'
   spec.add_dependency 'rainbow', '~> 2.0'
   spec.add_dependency 'fog-aws', '~> 0.11.0'
   spec.add_dependency 'optimist', '~> 3.0'
-  spec.add_dependency 'aws-sdk'
 end

--- a/lib/awsutils/awslogs.rb
+++ b/lib/awsutils/awslogs.rb
@@ -1,5 +1,5 @@
 require 'optimist'
-require 'aws-sdk'
+require 'aws-sdk-cloudwatchlogs'
 require 'time'
 
 class LogGroupNotFoundError < StandardError; end

--- a/lib/awsutils/ec2latestimage.rb
+++ b/lib/awsutils/ec2latestimage.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'net/http'
 require 'optimist'
-# require 'aws-sdk' # see the comment on `image_details` below
+# require 'aws-sdk-ec2' # see the comment on `image_details` below
 
 module AwsUtils
   class Ec2LatestImage
@@ -11,7 +11,7 @@ module AwsUtils
           if opts[:ownedbyme]
             fail 'AWS_OWNER_ID not defined' unless ENV['AWS_OWNER_ID']
 
-            require 'aws-sdk'
+            require 'aws-sdk-ec2'
 
             ubuntu_images =
               connection.describe_images(owners: [ENV['AWS_OWNER_ID']]).images.select do |image|


### PR DESCRIPTION
Avoids installing a huge swath of gems that we have no need for.