### PR TITLE
Fix funky memoizing in ec2info

### DIFF
--- a/lib/awsutils/ec2info.rb
+++ b/lib/awsutils/ec2info.rb
@@ -51,7 +51,7 @@ module AwsUtils
     # TODO: Naming/MemoizedInstanceVariableName: Memoized variable @instance_ids does
     # not match method name instances.
     def instances
-      @instance_ids ||= begin
+      @instances ||= begin
         if $DEBUG
           puts 'Entering instance_ids'
           puts "Search Term: #{search_terms.inspect}"
@@ -134,9 +134,7 @@ module AwsUtils
              'Flavor',
              'State')
 
-      instance_ids.each do |instance_id|
-        inst = ec2.servers.get(instance_id)
-
+      instances.each do |inst|
         s_color = get_state_color(inst.state)
         f_color = get_flavor_color(inst.flavor_id)
 

--- a/lib/awsutils/ec2info.rb
+++ b/lib/awsutils/ec2info.rb
@@ -141,7 +141,7 @@ module AwsUtils
         f_color = get_flavor_color(inst.flavor_id)
 
         printf(
-          "%-50s %-11s %-12s %-13s #{f_color}%-10s#{reset_color} #{s_color}%s#{reset_color}",
+          "%-50s %-11s %-12s %-13s #{f_color}%-10s#{reset_color} #{s_color}%s#{reset_color}\n",
           inst.tags['Name'],
           inst.availability_zone,
           inst.id,

--- a/lib/awsutils/ec2info.rb
+++ b/lib/awsutils/ec2info.rb
@@ -76,7 +76,7 @@ module AwsUtils
           exit 1
         end
 
-        puts "Found instances: #{results.inspect}" if $DEBUG
+        puts "Found instances: #{instance_ids.inspect}" if $DEBUG
 
         ec2.servers.all 'instance-id' => instance_ids
       end


### PR DESCRIPTION
This does a few things:

* Cleans up the memoizing of instances
* Avoids an additional AWS API call via fog to get individual instance info
* Adds a missing line break in the short listing
* Fixes a busted debug message

All of this should be refactored to use aws-sdk-ec2 instead of fog, but that’s a much larger undertaking.